### PR TITLE
Added check for format of the secret

### DIFF
--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -357,16 +357,15 @@ function updateSecret(callback) {
     });
 }
 
-function checkSecret(secret, type)
-{
+function checkSecret(secret, type) {
 	switch (type) {
-		case "base32":
+		case 'base32':
 		   	var base32RegEx =  /[^a-z2-7=]/gi;
-		    return base32RegEx.test(secret) ? true : false;
+		    return base32RegEx.test(secret);
 		
-		case "hex":
+		case 'hex':
 			var hexRegEx = /[^a-f0-9]/gi;
-			return hexRegEx.test(secret) ? true : false;
+			return hexRegEx.test(secret);
 	}
 }
 
@@ -378,24 +377,17 @@ function saveSecret() {
         showMessage(chrome.i18n.getMessage('err_acc_sec'));
         return;
     }
-    var battleRegEx = /^((bliz-)|(blz-))/gi;     
-    if(battleRegEx.test(secret))
-    {
-    	var tmp = secret.substring(secret.indexOf("-") + 1);
-    	if(checkSecret(tmp, "base32"))
-	    {
+    var battleRegEx = /^(bliz-|blz-)/gi;     
+    if(battleRegEx.test(secret)) {
+    	var tmp = secret.substring(secret.indexOf('-') + 1);
+    	if(checkSecret(tmp, 'base32')) {
 	    	showMessage(chrome.i18n.getMessage('errorsecret') + secret);
         	return;	    	
 		}
-    }
-	else if(checkSecret(secret, "hex"))
-    {
-	    if(checkSecret(secret, "base32"))
-	    {
-	    	showMessage(chrome.i18n.getMessage('errorsecret') + secret);
-        	return;
-	    }
-    }
+    } else if(checkSecret(secret, 'hex') && checkSecret(secret, 'base32')) {
+	    showMessage(chrome.i18n.getMessage('errorsecret') + secret);
+        return;
+	}
     updateSecret(function () {
         chrome.storage.sync.get(function (result) {
             var index = Object.keys(result).length;

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -357,6 +357,19 @@ function updateSecret(callback) {
     });
 }
 
+function checkSecret(secret, type)
+{
+	switch (type) {
+		case "base32":
+		   	var base32RegEx =  /[^a-z2-7=]/gi;
+		    return base32RegEx.test(secret) ? true : false;
+		
+		case "hex":
+			var hexRegEx = /[^a-f0-9]/gi;
+			return hexRegEx.test(secret) ? true : false;
+	}
+}
+
 function saveSecret() {
     var account = document.getElementById('account_input').value;
     var secret = document.getElementById('secret_input').value;
@@ -365,10 +378,23 @@ function saveSecret() {
         showMessage(chrome.i18n.getMessage('err_acc_sec'));
         return;
     }
-    var checkSecretFormat = /(?=.*[g-z])(?=.*[0|1])/gi;  
-    if(checkSecretFormat.test(secret)) {
-        showMessage(chrome.i18n.getMessage('errorsecret') + secret);
-        return;
+    var battleRegEx = /^((bliz-)|(blz-))/gi;     
+    if(battleRegEx.test(secret))
+    {
+    	var tmp = secret.substring(secret.indexOf("-") + 1);
+    	if(checkSecret(tmp, "base32"))
+	    {
+	    	showMessage(chrome.i18n.getMessage('errorsecret') + secret);
+        	return;	    	
+		}
+    }
+	else if(checkSecret(secret, "hex"))
+    {
+	    if(checkSecret(secret, "base32"))
+	    {
+	    	showMessage(chrome.i18n.getMessage('errorsecret') + secret);
+        	return;
+	    }
     }
     updateSecret(function () {
         chrome.storage.sync.get(function (result) {

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -365,6 +365,11 @@ function saveSecret() {
         showMessage(chrome.i18n.getMessage('err_acc_sec'));
         return;
     }
+    var checkSecretFormat = /(?=.*[g-z])(?=.*[0|1])/gi;  
+    if(checkSecretFormat.test(secret)) {
+        showMessage(chrome.i18n.getMessage('errorsecret') + secret);
+        return;
+    }
     updateSecret(function () {
         chrome.storage.sync.get(function (result) {
             var index = Object.keys(result).length;


### PR DESCRIPTION
Hi,
I have added a check for the format of the `secret` when the user adds a new account. It shows an alert if the `secret` is not it `Base32` or `Hex` format. I have implemented it using a `Regular Expression`.

I added this as per our conversation over #46 .