### PR TITLE
Distinguish between top and bottom of minute.

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -227,6 +227,10 @@ body {
     cursor: pointer;
 }
 
+.codeBottomThirty {
+    color: #3C2;
+}
+
 #codes.edit .code {
     color: #CCC!important;
     -webkit-user-select: none;

--- a/css/popup.css
+++ b/css/popup.css
@@ -227,8 +227,8 @@ body {
     cursor: pointer;
 }
 
-.codeBottomThirty {
-    color: #3C2;
+.codeCopied {
+    color: #C0B;
 }
 
 #codes.edit .code {

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -10,7 +10,6 @@ var editTimeout;
 var decodedPhrase;
 var shownPassphrase = false;
 var capturing = false;
-var isBottomOfMinute = false;
 
 if (localStorage.phrase) {
     decodedPhrase = localStorage.phrase;
@@ -578,11 +577,6 @@ function update() {
     if (localStorage.offset) {
         second += Number(localStorage.offset) + 30;
     }
-    var localIsBottomOfMinute = second / 30 >= 1;
-    if(localIsBottomOfMinute != isBottomOfMinute) {
-        isBottomOfMinute = localIsBottomOfMinute;
-        toggleCodeClass(isBottomOfMinute, 'codeBottomThirty');
-    }
     
     second = second % 30;
     if (second > 25) {
@@ -592,19 +586,14 @@ function update() {
     }
     if (second < 1) {
         updateCode();
+		resetCodesSelectedClass();
     }
 }
 
-function toggleCodeClass(toggleOn, cssClass) {
+function resetCodesSelectedClass() {
     var codes = document.getElementsByClassName('code');
     for(var i = 0; i < codes.length; i++){
-        if(toggleOn){
-            if(!codes[i].classList.contains(cssClass)) {
-                codes[i].classList.add(cssClass);
-            }
-        } else {
-            codes[i].classList.remove(cssClass);
-        }
+        codes[i].classList.remove('codeCopied');
     }
 }
 
@@ -810,6 +799,7 @@ function showExport() {
 }
 
 function copyCode() {
+    var that = this;
     var code = this.innerText;
     if ('Encrypted' == code) {
         document.getElementById('passphrase').className = 'fadein';
@@ -830,6 +820,9 @@ function copyCode() {
             codeClipboard.select();
             document.execCommand('Copy');
             showNotification(chrome.i18n.getMessage('copied'));
+            if(!that.classList.contains('codeCopied')) {
+                that.classList.add('codeCopied');
+            }
         }
     });
 }

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -10,6 +10,7 @@ var editTimeout;
 var decodedPhrase;
 var shownPassphrase = false;
 var capturing = false;
+var isBottomOfMinute = false;
 
 if (localStorage.phrase) {
     decodedPhrase = localStorage.phrase;
@@ -577,6 +578,12 @@ function update() {
     if (localStorage.offset) {
         second += Number(localStorage.offset) + 30;
     }
+	var localIsBottomOfMinute = second / 30 >= 1;
+	if(localIsBottomOfMinute != isBottomOfMinute) {
+		isBottomOfMinute = localIsBottomOfMinute;
+		toggleCodeClass(isBottomOfMinute, 'codeBottomThirty');
+	}
+	
     second = second % 30;
     if (second > 25) {
         document.getElementById('codes').className = 'timeout';
@@ -586,6 +593,19 @@ function update() {
     if (second < 1) {
         updateCode();
     }
+}
+
+function toggleCodeClass(toggleOn, cssClass) {
+	var codes = document.getElementsByClassName('code');
+	for(var i = 0; i < codes.length; i++){
+		if(toggleOn){
+			if(!codes[i].classList.contains(cssClass)) {
+				codes[i].classList.add(cssClass);
+			}
+		} else {
+			codes[i].classList.remove(cssClass);
+		}
+	}
 }
 
 function getSector() {

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -578,12 +578,12 @@ function update() {
     if (localStorage.offset) {
         second += Number(localStorage.offset) + 30;
     }
-	var localIsBottomOfMinute = second / 30 >= 1;
-	if(localIsBottomOfMinute != isBottomOfMinute) {
-		isBottomOfMinute = localIsBottomOfMinute;
-		toggleCodeClass(isBottomOfMinute, 'codeBottomThirty');
-	}
-	
+    var localIsBottomOfMinute = second / 30 >= 1;
+    if(localIsBottomOfMinute != isBottomOfMinute) {
+        isBottomOfMinute = localIsBottomOfMinute;
+        toggleCodeClass(isBottomOfMinute, 'codeBottomThirty');
+    }
+    
     second = second % 30;
     if (second > 25) {
         document.getElementById('codes').className = 'timeout';
@@ -596,16 +596,16 @@ function update() {
 }
 
 function toggleCodeClass(toggleOn, cssClass) {
-	var codes = document.getElementsByClassName('code');
-	for(var i = 0; i < codes.length; i++){
-		if(toggleOn){
-			if(!codes[i].classList.contains(cssClass)) {
-				codes[i].classList.add(cssClass);
-			}
-		} else {
-			codes[i].classList.remove(cssClass);
-		}
-	}
+    var codes = document.getElementsByClassName('code');
+    for(var i = 0; i < codes.length; i++){
+        if(toggleOn){
+            if(!codes[i].classList.contains(cssClass)) {
+                codes[i].classList.add(cssClass);
+            }
+        } else {
+            codes[i].classList.remove(cssClass);
+        }
+    }
 }
 
 function getSector() {

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -577,7 +577,6 @@ function update() {
     if (localStorage.offset) {
         second += Number(localStorage.offset) + 30;
     }
-    
     second = second % 30;
     if (second > 25) {
         document.getElementById('codes').className = 'timeout';
@@ -586,7 +585,7 @@ function update() {
     }
     if (second < 1) {
         updateCode();
-		resetCodesSelectedClass();
+        resetCodesSelectedClass();
     }
 }
 


### PR DESCRIPTION
Add a check to set the text to a different color during the bottom half of the minute (seconds 31-60).

I use the extension at work and have to sign in once on vpn and again in a SSO location.  Both use the same creds.  I often get a failed login on the second authentication because I used the token in the first (VPN) authentication.  I then have to wait for the next round and retry the authentication.  

This helps to indicate whether or not I need to wait for the next token, knowing the last code I used was color X, prior to trying the second authentication.  While one could read the code, I usually just click on the code and paste it without giving heed to the actual value.
