### PR TITLE
Show QR button on hover

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -299,7 +299,7 @@ body {
     opacity: 0;
 }
 
-.showqr:hover {
+.codeBox:hover .showqr {
     opacity: 1;
 }
 


### PR DESCRIPTION
Instead of making the QR button near impossible to find unless you are looking for it, this makes it so that it shows on hover of a `codeBox`